### PR TITLE
deps: upgrade Django 6.0 and dj-database-url 3.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django>=5.1,<6
-dj-database-url>=2.2,<3
+Django>=6.0,<7
+dj-database-url>=3.1,<4
 psycopg[binary]>=3.2,<4
 requests>=2.32,<3


### PR DESCRIPTION
Bumps the two Python dependencies that had new majors available, plus syncs the local `vercel` install (lockfile already pinned 54.15.1).

## Changes
| Package | Before | After |
|---|---|---|
| Django | 5.2.15 | 6.0.6 |
| dj-database-url | 2.3.0 | 3.1.2 |

`requirements.txt` caps updated to `<7` and `<4` respectively. `psycopg`/`requests` were already latest-in-range.

## Compatibility — verified
- **Vercel + Django 6**: Vercel's default Python runtime is **3.12** (Django 6.0's minimum). No Python version is pinned, so the build gets the default. ✅
- **Django 6 breaking changes**: `DEFAULT_AUTO_FIELD` → `BigAutoField` is a no-op (already set explicitly in `settings.py`); Email API changes don't apply.
- **dj-database-url 3.x**: `config()` signature unchanged; Neon Postgres URL parses to the correct engine/host.
- **Tests**: 57/57 pass on the upgraded stack.
- **`manage.py check --deploy`**: clean except the pre-existing `SECURE_SSL_REDIRECT` warning (intentional — Vercel redirects at the edge).
- **Production entry**: `api/index.py` WSGI app boots under Django 6.

Will only be fully proven once Vercel rebuilds with the new `requirements.txt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)