### PR TITLE
Fix iNaturalist matching: compare local wall-clock, not UTC instant

### DIFF
--- a/core/services/inaturalist.py
+++ b/core/services/inaturalist.py
@@ -24,9 +24,10 @@ def collect_species(user_id: str, activities: list[IdDates]) -> dict[int, dict[s
         taxon = obs.get("taxon")
         if not ts or not taxon:
             continue
-        observed = datetime.fromisoformat(ts)
-        if observed.tzinfo is None:
-            observed = observed.replace(tzinfo=timezone.utc)
+        # Match eBird/Strava: compare local wall-clock, not the true UTC instant.
+        # iNat sends a real offset; drop it so 07:30 local lines up with the
+        # activity window (also stored as local wall-clock labeled UTC).
+        observed = datetime.fromisoformat(ts).replace(tzinfo=timezone.utc)
         name = taxon.get("preferred_common_name") or taxon.get("name")
         if not name:
             continue

--- a/core/tests/test_inaturalist.py
+++ b/core/tests/test_inaturalist.py
@@ -33,6 +33,20 @@ class CollectSpeciesTests(SimpleTestCase):
         )
 
     @patch("core.services.inaturalist.requests.get")
+    def test_matches_on_local_wall_clock_not_utc_instant(self, get):
+        # iNat sends a real offset; activities/eBird store local wall-clock as UTC.
+        # 07:30 local is inside the 07:00-08:00 window even though 07:30-07:00 is 14:30 UTC.
+        get.return_value = _resp({"results": [
+            {"time_observed_at": "2026-06-01T07:30:00-07:00",
+             "taxon": {"preferred_common_name": "Ring-necked Snake",
+                       "name": "Diadophis punctatus"}},
+        ]})
+        self.assertEqual(
+            inaturalist.collect_species("me", [_activity()]),
+            {99: {"Ring-necked Snake": ""}},
+        )
+
+    @patch("core.services.inaturalist.requests.get")
     def test_falls_back_to_scientific_name(self, get):
         get.return_value = _resp({"results": [
             {"time_observed_at": "2026-06-01T07:30:00+00:00",


### PR DESCRIPTION
## Problem

Saturday's Strava activity (ID `19092643740`) was never updated with iNaturalist observations, even though `brad_burch` logged 5 observations squarely inside the activity window.

## Root cause

A time-zone reference-frame mismatch — not a date-window bug.

The whole app runs in one convention: **local wall-clock, labeled UTC**. eBird (`ebird.py:22`) and Strava (`strava.py:29`) both parse a local timestamp and `.replace(tzinfo=utc)` *without converting*, so they share a frame and match.

iNaturalist was the outlier: `time_observed_at` carries a real offset (`-07:00`), and `fromisoformat` *kept* it, producing a true-UTC instant. The old `if tzinfo is None` guard only normalized timestamps *missing* an offset — but iNat always sends one, so it never fired. Net effect for a Pacific user: every observation landed 7 hours "after" the window and never overlapped.

## Fix

Drop iNat's offset and label the wall-clock as UTC, matching the eBird/Strava convention (one line).

## Verification

- Reproduced against the real DB activity window + live iNat API: all 5 Saturday species now match (was `{}` before).
- Added a regression test using a non-zero offset — the existing tests all used `+00:00`, which is exactly why they never caught this.
- Full suite: 98 tests pass.

## Note

To update Saturday's activity after merge/deploy: the queued recheck row will succeed on its next cron run, or hit **Sync now** on the dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)