### PR TITLE
Keep users logged in across sessions; fix sync message + add footer

### DIFF
--- a/core/templates/core/base.html
+++ b/core/templates/core/base.html
@@ -105,6 +105,8 @@
     .stack > * + *{ margin-top:1.35rem }
     .who{ color:var(--ink-soft) }
     .who b{ color:var(--ink); font-weight:600 }
+    .colophon{ margin-top:3rem; padding-top:1.1rem; border-top:1px solid var(--line);
+      font-family:var(--mono); font-size:.78rem; letter-spacing:.04em; color:var(--muted); }
 
     /* motion */
     @keyframes rise{ from{opacity:0; transform:translateY(12px)} to{opacity:1; transform:none} }
@@ -124,6 +126,7 @@
     <hr class="rule">
     {% if messages %}<div class="flashes">{% for message in messages %}<div class="flash flash--{{ message.tags }}">{{ message|safe }}</div>{% endfor %}</div>{% endif %}
     <main class="stack" style="margin-top:1.6rem">{% block content %}{% endblock %}</main>
+    <footer class="colophon">Created by Brad Burch</footer>
   </div>
 </body>
 </html>

--- a/core/tests/test_views.py
+++ b/core/tests/test_views.py
@@ -78,6 +78,16 @@ class LandingTests(TestCase):
         self.assertContains(resp, "Nature seen during activity:")
         self.assertNotContains(resp, "Birds seen during activity:")
 
+    def test_landing_redirects_authenticated_user_to_dashboard(self):
+        user = User.objects.create(username="7")
+        Profile.objects.create(
+            user=user, strava_athlete_id=7, access_token="a", refresh_token="r",
+            expires_at=dj_timezone.now() + timedelta(hours=1),
+        )
+        self.client.force_login(user)
+        resp = self.client.get(reverse("core:landing"))
+        self.assertRedirects(resp, reverse("core:dashboard"))
+
 
 class DashboardTests(TestCase):
     def _login(self):

--- a/core/views.py
+++ b/core/views.py
@@ -27,6 +27,10 @@ WEBHOOK_COOLDOWN_SECONDS = 30
 
 
 def landing(request):
+    # A returning, still-authenticated user shouldn't be shown the "Connect with
+    # Strava" page (and pushed back through OAuth) — send them to the dashboard.
+    if request.user.is_authenticated:
+        return redirect("core:dashboard")
     return render(request, "core/landing.html")
 
 
@@ -137,8 +141,9 @@ def sync_now(request):
             '<a href="https://www.strava.com/activities/{0}" target="_blank" rel="noopener">{0}</a>',
             ((activity_id,) for activity_id in updated),
         )
+        noun = "activity" if len(updated) == 1 else "activities"
         messages.success(
-            request, format_html("Updated {} activity(ies): {}", len(updated), links)
+            request, format_html("Updated {} {}: {}", len(updated), noun, links)
         )
     else:
         messages.info(request, "No matching observations found for recent activities.")

--- a/roadrunner/settings.py
+++ b/roadrunner/settings.py
@@ -69,6 +69,10 @@ USE_TZ = True
 
 LOGIN_URL = "core:landing"
 
+# Keep users logged in across visits: refresh the 2-week session window on every
+# request, so an active user never has to re-auth with Strava just to sign in.
+SESSION_SAVE_EVERY_REQUEST = True
+
 # App-specific config (read by core.services)
 EBIRD_API_TOKEN = os.environ.get("EBIRD_API_TOKEN", "")
 STRAVA_CLIENT_ID = os.environ.get("STRAVA_CLIENT_ID", "")


### PR DESCRIPTION
## What

- **Persist login across sessions.** A still-authenticated user hitting `/` was shown the "Connect with Strava" landing page and pushed back through OAuth. `landing()` now redirects authenticated users to the dashboard, and `SESSION_SAVE_EVERY_REQUEST = True` slides the 2-week session window on every request so an active user never gets logged out mid-use.
- **Fix sync flash pluralization.** "Updated N activity(ies)" → "1 activity" / "N activities".
- **Add footer.** "Created by Brad Burch" on every page.

## Notes

No DB migration — the session change is config, not schema. Relies on a stable `SECRET_KEY` in production (confirmed set).

## Test

`python manage.py test core.tests.test_views` — 40/40 pass, including a new test asserting an authenticated user is redirected from `/` to the dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)